### PR TITLE
Quick fix for APMinit tracker.apworld

### DIFF
--- a/index/tracker.json
+++ b/index/tracker.json
@@ -691,8 +691,8 @@
       "source_url": "https://api.github.com/repos/qwint/APMinit",
       "tag": "v0.2.1",
       "title": "Tracker update!",
-      "version_simple": "0.2.1",
-      "world_version": "0.2.1"
+      "version_simple": "0.0.21",
+      "world_version": "0.0.21"
     },
     "v0.3.0": {
       "created_at": "2023-11-16T05:17:22Z",
@@ -703,8 +703,8 @@
       "source_url": "https://api.github.com/repos/qwint/APMinit",
       "tag": "v0.3.0",
       "title": "Deathlink enabled!",
-      "version_simple": "0.3.0",
-      "world_version": "0.3.0"
+      "version_simple": "0.0.30",
+      "world_version": "0.0.30"
     },
     "v0.4.0": {
       "created_at": "2023-11-23T01:35:53Z",
@@ -715,8 +715,8 @@
       "source_url": "https://api.github.com/repos/qwint/APMinit",
       "tag": "v0.4.0",
       "title": "Entrance Rando... (kinda!)",
-      "version_simple": "0.4.0",
-      "world_version": "0.4.0"
+      "version_simple": "0.0.40",
+      "world_version": "0.0.40"
     },
     "v0.5.0": {
       "created_at": "2023-11-30T08:28:16Z",
@@ -727,8 +727,8 @@
       "source_url": "https://api.github.com/repos/qwint/APMinit",
       "tag": "v0.5.0",
       "title": "Progressive Sword, Coin prompts, Goal locking, oh my",
-      "version_simple": "0.5.0",
-      "world_version": "0.5.0"
+      "version_simple": "0.0.50",
+      "world_version": "0.0.50"
     },
     "v0.6.0": {
       "created_at": "2024-02-05T06:40:11Z",
@@ -739,8 +739,8 @@
       "source_url": "https://api.github.com/repos/qwint/APMinit",
       "tag": "v0.6.0",
       "title": "I'm mostly pushing this so the Stripes webhost has actual docs",
-      "version_simple": "0.6.0",
-      "world_version": "0.6.0"
+      "version_simple": "0.0.60",
+      "world_version": "0.0.60"
     },
     "v0.6.1": {
       "created_at": "2024-02-18T20:34:11Z",
@@ -751,8 +751,8 @@
       "source_url": "https://api.github.com/repos/qwint/APMinit",
       "tag": "v0.6.1",
       "title": "Mostly ER fixes (but some new options too!)",
-      "version_simple": "0.6.1",
-      "world_version": "0.6.1"
+      "version_simple": "0.0.61",
+      "world_version": "0.0.61"
     }
   }
 }


### PR DESCRIPTION
Just made all "version_simple", and "world_version" for APMinit way too small to matter.
Example: 0.2.1 -> 0.0.21