### PR TITLE
Minecraft Fabric remove fork

### DIFF
--- a/index/minecraft_fabric.json
+++ b/index/minecraft_fabric.json
@@ -4,8 +4,7 @@
   ],
   "game": "Minecraft Fabric",
   "github": [
-    "https://github.com/Deadlydiamond98/MinecraftFabricAPWorld",
-    "https://github.com/ayancey/MinecraftFabricAPWorld"
+    "https://github.com/Deadlydiamond98/MinecraftFabricAPWorld"
   ],
   "license": null,
   "manifest_fields": [
@@ -14,18 +13,6 @@
     "world_version"
   ],
   "versions": {
-    "test3": {
-      "created_at": "2026-01-22T05:01:03Z",
-      "download_url": "https://github.com/ayancey/MinecraftFabricAPWorld/releases/download/test3/minecraft_fabric.apworld",
-      "has_manifest": false,
-      "hash_sha256": "49bc0333754f7a31302028a699cf2b9a544bdfb8a7e4f3b09e45b818071af612",
-      "size": 12863,
-      "source_url": "https://api.github.com/repos/ayancey/MinecraftFabricAPWorld",
-      "tag": "test3",
-      "title": "test3",
-      "version_simple": "3",
-      "world_version": "3"
-    },
     "v.1.0.4-alpha": {
       "created_at": "2026-01-25T12:40:13Z",
       "download_url": "https://github.com/Deadlydiamond98/MinecraftFabricAPWorld/releases/download/v.1.0.4-alpha/minecraft_fabric.apworld",


### PR DESCRIPTION
I'm not sure why the fork is included, but it causes APWorld Manager to think that the fork version is newer than the latest release in the main repository. `test3` may have a higher version number than `1.0.6a0`, but the latter was released later. Perhaps APWorld Manager should use the release date rather than the version number to determine which version is newer.