### PR TITLE
SMRPG Removing old repo

### DIFF
--- a/index/smrpg.json
+++ b/index/smrpg.json
@@ -2,7 +2,6 @@
   "description": "Croakacola",
   "game": "Super Mario RPG Legend of the Seven Stars",
   "github": [
-    "https://github.com/Rosalie-A/Archipelago",
     "https://github.com/TheRealSolidusSnake/SMRPG_apworld"
   ],
   "license": null,
@@ -121,42 +120,6 @@
       "title": "Ask for ROM before generation",
       "version_simple": "0.0.8",
       "world_version": "0.0.8.post2"
-    },
-    "SMRPG-0.1": {
-      "created_at": "2022-09-20T19:33:58Z",
-      "download_url": "https://github.com/Rosalie-A/Archipelago/releases/download/SMRPG-0.1/smrpg.apworld",
-      "has_manifest": false,
-      "hash_sha256": "8b5ed6f8c59473ca37383f0841b3a361cc513021b5ac8e75d452cf937da90bf1",
-      "size": 1473604,
-      "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
-      "tag": "SMRPG-0.1",
-      "title": "SMRPG 0.1",
-      "version_simple": "0.1",
-      "world_version": "0.1"
-    },
-    "SMRPG-0.2": {
-      "created_at": "2022-09-20T19:33:58Z",
-      "download_url": "https://github.com/Rosalie-A/Archipelago/releases/download/SMRPG-0.2/smrpg.apworld",
-      "has_manifest": false,
-      "hash_sha256": "29a07021dc014ef99d8064b9e78d8cbb094787bda0f70de4137c8b8321a9a1c6",
-      "size": 1474071,
-      "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
-      "tag": "SMRPG-0.2",
-      "title": "SMRPG 0.2",
-      "version_simple": "0.2",
-      "world_version": "0.2"
-    },
-    "SMRPG-0.3": {
-      "created_at": "2022-09-20T19:33:58Z",
-      "download_url": "https://github.com/Rosalie-A/Archipelago/releases/download/SMRPG-0.3/smrpg.apworld",
-      "has_manifest": false,
-      "hash_sha256": "458f0cf38a542b1da7494ff2b6f707e5d2809343b1006c46cf52464f4add013a",
-      "size": 1478906,
-      "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
-      "tag": "SMRPG-0.3",
-      "title": "SMRPG 0.3",
-      "version_simple": "0.3",
-      "world_version": "0.3"
     }
   }
 }


### PR DESCRIPTION
The old Rosalie releases are confusing APWorld Manager to be newer than the latest releases in the new repo.

(Shame on me for misspelling Rosalie in the commit message)