### PR TITLE
Fix Portal 2 missed manifest update.

### DIFF
--- a/index/portal2.json
+++ b/index/portal2.json
@@ -198,8 +198,8 @@
       "source_url": "https://api.github.com/repos/GlassToadstool/Archipelago",
       "tag": "0.5.6",
       "title": "Portal 2 Archipelago v0.5.6",
-      "version_simple": "0.5.2",
-      "world_version": "0.5.2"
+      "version_simple": "0.5.6",
+      "world_version": "0.5.6"
     },
     "0.5r2": {
       "created_at": "2026-01-27T19:25:12Z",


### PR DESCRIPTION
Portal 2 forgot to update their world version in manifest.