### PR TITLE
Metroid Fusion: Renumbering old versions

### DIFF
--- a/index/metroidfusion.json
+++ b/index/metroidfusion.json
@@ -19,8 +19,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v1",
       "title": "Metroid Fusion APWorld v1",
-      "version_simple": "1",
-      "world_version": "1"
+      "version_simple": "0.1.0",
+      "world_version": "0.1.0"
     },
     "MF-v10": {
       "created_at": "2025-07-03T20:10:54Z",
@@ -33,8 +33,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v10",
       "title": "Metroid Fusion APWorld v10",
-      "version_simple": "10",
-      "world_version": "10"
+      "version_simple": "0.10.0",
+      "world_version": "0.10.0"
     },
     "MF-v11": {
       "created_at": "2025-09-06T14:09:07Z",
@@ -47,8 +47,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v11",
       "title": "Metroid Fusion APWorld v11",
-      "version_simple": "11",
-      "world_version": "11"
+      "version_simple": "0.11.0",
+      "world_version": "0.11.0"
     },
     "MF-v12": {
       "created_at": "2025-09-08T23:55:41Z",
@@ -58,8 +58,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v12",
       "title": "Metroid Fusion APWorld v12",
-      "version_simple": "12",
-      "world_version": "12"
+      "version_simple": "0.12.0",
+      "world_version": "0.12.0"
     },
     "MF-v12r2": {
       "created_at": "2025-09-08T23:55:41Z",
@@ -72,8 +72,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v12r2",
       "title": "Metroid Fusion APWorld v12",
-      "version_simple": "12",
-      "world_version": "12.post2"
+      "version_simple": "0.12.0",
+      "world_version": "0.12.2"
     },
     "MF-v13": {
       "created_at": "2025-09-09T15:16:12Z",
@@ -86,8 +86,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v13",
       "title": "Metroid Fusion APWorld v13",
-      "version_simple": "13",
-      "world_version": "13"
+      "version_simple": "0.13.0",
+      "world_version": "0.13.0"
     },
     "MF-v14": {
       "created_at": "2025-09-11T13:19:19Z",
@@ -100,8 +100,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v14",
       "title": "Metroid Fusion APWorld v14",
-      "version_simple": "14",
-      "world_version": "14"
+      "version_simple": "0.14.0",
+      "world_version": "0.14.0"
     },
     "MF-v15": {
       "created_at": "2025-09-16T16:23:28Z",
@@ -114,8 +114,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v15",
       "title": "Metroid Fusion APWorld v15",
-      "version_simple": "15",
-      "world_version": "15"
+      "version_simple": "0.15.0",
+      "world_version": "0.15.0"
     },
     "MF-v16": {
       "created_at": "2025-10-03T23:14:06Z",
@@ -128,8 +128,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v16",
       "title": "Metroid Fusion APWorld v16",
-      "version_simple": "16",
-      "world_version": "16"
+      "version_simple": "0.16.0",
+      "world_version": "0.16.0"
     },
     "MF-v17": {
       "created_at": "2025-10-04T14:54:16Z",
@@ -142,8 +142,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v17",
       "title": "Metroid Fusion APWorld v17",
-      "version_simple": "17",
-      "world_version": "17"
+      "version_simple": "0.17.0",
+      "world_version": "0.17.0"
     },
     "MF-v2": {
       "created_at": "2025-04-06T22:39:25Z",
@@ -156,8 +156,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v2",
       "title": "Metroid Fusion APWorld v2",
-      "version_simple": "2",
-      "world_version": "2"
+      "version_simple": "0.2.0",
+      "world_version": "0.2.0"
     },
     "MF-v3": {
       "created_at": "2025-06-19T18:26:32Z",
@@ -170,8 +170,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v3",
       "title": "Metroid Fusion APWorld v3",
-      "version_simple": "3",
-      "world_version": "3"
+      "version_simple": "0.3.0",
+      "world_version": "0.3.0"
     },
     "MF-v4": {
       "created_at": "2025-06-21T00:25:24Z",
@@ -184,8 +184,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v4",
       "title": "Metroid Fusion APWorld v4",
-      "version_simple": "4",
-      "world_version": "4"
+      "version_simple": "0.4.0",
+      "world_version": "0.4.0"
     },
     "MF-v5": {
       "created_at": "2025-06-22T16:24:51Z",
@@ -198,8 +198,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v5",
       "title": "Metroid Fusion APWorld v5",
-      "version_simple": "5",
-      "world_version": "5"
+      "version_simple": "0.5.0",
+      "world_version": "0.5.0"
     },
     "MF-v6": {
       "created_at": "2025-06-23T20:05:51Z",
@@ -212,8 +212,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v6",
       "title": "Metroid Fusion APWorld v6",
-      "version_simple": "6",
-      "world_version": "6"
+      "version_simple": "0.6.0",
+      "world_version": "0.6.0"
     },
     "MF-v7": {
       "created_at": "2025-06-27T23:30:04Z",
@@ -226,8 +226,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v7",
       "title": "Metroid Fusion APWorld v7",
-      "version_simple": "7",
-      "world_version": "7"
+      "version_simple": "0.7.0",
+      "world_version": "0.7.0"
     },
     "MF-v8": {
       "created_at": "2025-06-30T16:05:52Z",
@@ -240,8 +240,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v8",
       "title": "Metroid Fusion APWorld v8",
-      "version_simple": "8",
-      "world_version": "8"
+      "version_simple": "0.8.0",
+      "world_version": "0.8.0"
     },
     "MF-v9": {
       "created_at": "2025-07-02T19:26:50Z",
@@ -254,8 +254,8 @@
       "source_url": "https://api.github.com/repos/Rosalie-A/Archipelago",
       "tag": "MF-v9",
       "title": "Metroid Fusion APWorld v9",
-      "version_simple": "9",
-      "world_version": "9"
+      "version_simple": "0.9.0",
+      "world_version": "0.9.0"
     },
     "v1.22.0": {
       "created_at": "2026-05-05T18:23:29Z",
@@ -296,8 +296,8 @@
       "source_url": "https://api.github.com/repos/StalledStorm/ArchipelagoMine",
       "tag": "v18",
       "title": "Metroid Fusion APWorld v18",
-      "version_simple": "18",
-      "world_version": "18"
+      "version_simple": "0.18.0",
+      "world_version": "0.18.0"
     },
     "v19": {
       "created_at": "2026-02-08T17:39:49Z",
@@ -310,8 +310,8 @@
       "source_url": "https://api.github.com/repos/StalledStorm/ArchipelagoMine",
       "tag": "v19",
       "title": "Metroid Fusion APWorld v19",
-      "version_simple": "19",
-      "world_version": "19"
+      "version_simple": "0.19.0",
+      "world_version": "0.19.0"
     },
     "v20": {
       "created_at": "2026-03-21T07:34:43Z",
@@ -324,8 +324,8 @@
       "source_url": "https://api.github.com/repos/StalledStorm/ArchipelagoMine",
       "tag": "v20",
       "title": "Metroid Fusion APWorld v20",
-      "version_simple": "20",
-      "world_version": "20"
+      "version_simple": "0.20.0",
+      "world_version": "0.20.0"
     },
     "v21": {
       "created_at": "2026-03-22T08:17:33Z",
@@ -338,8 +338,8 @@
       "source_url": "https://api.github.com/repos/StalledStorm/ArchipelagoMine",
       "tag": "v21",
       "title": "Metroid Fusion APWorld v21",
-      "version_simple": "21",
-      "world_version": "21"
+      "version_simple": "0.21.0",
+      "world_version": "0.21.0"
     }
   }
 }


### PR DESCRIPTION
Changed the numbering of older versions to match the new versions.