### PR TITLE
Update papermario.json github array & license

### DIFF
--- a/index/papermario.json
+++ b/index/papermario.json
@@ -1,8 +1,11 @@
 {
   "description": "Paper Mario is a turn-based adventure RPG. Bowser has kidnapped Princess Peach along with her castle using the\npower of the Star Rod, which grants the wishes of the holder. You must rescue the Star Spirits so that they can\nhelp you take back the Star Rod from Bowser and save Peach. You will have to defeat powerful foes\nand venture through dangerous lands with the help of partners you meet along the way.",
   "game": "Paper Mario",
-  "github": "https://github.com/JKBSunshine/PMR_APWorld",
-  "license": "GPL-3.0",
+  "github": [
+    "https://github.com/JKBSunshine/PMR_APWorld",
+    "https://github.com/icebound777/PMR_APWorld"
+  ],
+  "license": "MIT",
   "manifest_fields": [],
   "versions": {
     "v0.1.5": {


### PR DESCRIPTION
Owner of repo changed recently (ref on archipelago server, paper-mario-64 channel: https://discord.com/channels/731205301247803413/1369329691076329582/1507394955377643620) .  
New repo has one release with a higher semver than the original repo's latest release.

The license changed even before the github URL change, but it seems like it wasn't ever updated in the apworld manager.