### PR TITLE
Fix Tevi

### DIFF
--- a/index/tevi.json
+++ b/index/tevi.json
@@ -412,7 +412,7 @@
       "tag": "v1.4.5",
       "title": "Tevi Randomizer v1.4.5 (AP 0.6.5)",
       "version_simple": "0.6.5",
-      "world_version": "0.6.5"
+      "world_version": "0.6.5.post2""
     },
     "v1.4.6": {
       "created_at": "2026-01-11T12:07:22Z",
@@ -454,7 +454,7 @@
       "tag": "v1.4.8",
       "title": "Tevi Randomizer v1.4.8 (AP 0.6.7)",
       "version_simple": "0.6.7",
-      "world_version": "0.6.7"
+      "world_version": "0.6.7.post2""
     },
     "v1.4.9": {
       "created_at": "2026-03-05T18:11:30Z",
@@ -514,7 +514,7 @@
       "tag": "v1.5.2",
       "title": "Version 1.5.2 (AP v0.7.1)",
       "version_simple": "0.7.1",
-      "world_version": "0.7.1"
+      "world_version": "0.7.1.post2""
     },
     "v1.5.3": {
       "created_at": "2026-06-06T15:58:50Z",

--- a/index/tevi.json
+++ b/index/tevi.json
@@ -412,7 +412,7 @@
       "tag": "v1.4.5",
       "title": "Tevi Randomizer v1.4.5 (AP 0.6.5)",
       "version_simple": "0.6.5",
-      "world_version": "0.6.5.post2""
+      "world_version": "0.6.5.post2"
     },
     "v1.4.6": {
       "created_at": "2026-01-11T12:07:22Z",
@@ -454,7 +454,7 @@
       "tag": "v1.4.8",
       "title": "Tevi Randomizer v1.4.8 (AP 0.6.7)",
       "version_simple": "0.6.7",
-      "world_version": "0.6.7.post2""
+      "world_version": "0.6.7.post2"
     },
     "v1.4.9": {
       "created_at": "2026-03-05T18:11:30Z",
@@ -514,7 +514,7 @@
       "tag": "v1.5.2",
       "title": "Version 1.5.2 (AP v0.7.1)",
       "version_simple": "0.7.1",
-      "world_version": "0.7.1.post2""
+      "world_version": "0.7.1.post2"
     },
     "v1.5.3": {
       "created_at": "2026-06-06T15:58:50Z",

--- a/index/tevi.json
+++ b/index/tevi.json
@@ -45,8 +45,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "V1.4",
       "title": "Tevi Randomizer 1.4",
-      "version_simple": "1.4",
-      "world_version": "1.4"
+      "version_simple": "0.5.1400",
+      "world_version": "0.5.1400"
     },
     "V1.4.1": {
       "created_at": "2025-09-19T12:14:46Z",
@@ -59,8 +59,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "V1.4.1",
       "title": "Tevi Randomizer 1.4.1",
-      "version_simple": "1.4.1",
-      "world_version": "1.4.1"
+      "version_simple": "0.5.1410",
+      "world_version": "0.5.1410"
     },
     "V1.4.4": {
       "created_at": "2026-01-05T21:35:49Z",
@@ -73,8 +73,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "V1.4.4",
       "title": "Tevi Randomizer v1.4.4 (AP 0.6.5)",
-      "version_simple": "1.4.4",
-      "world_version": "1.4.4"
+      "version_simple": "0.6.5",
+      "world_version": "0.6.5"
     },
     "v0.6.3": {
       "created_at": "2025-10-17T10:57:21Z",
@@ -99,8 +99,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.2.1",
       "title": "Tevi Randomizer v1.2.1",
-      "version_simple": "1.2.1",
-      "world_version": "1.2.1"
+      "version_simple": "0.5.1210",
+      "world_version": "0.5.1210"
     },
     "v1.3": {
       "created_at": "2025-05-12T17:50:22Z",
@@ -113,8 +113,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.3",
       "title": "Tevi Randomizer v1.3",
-      "version_simple": "1.3",
-      "world_version": "1.3"
+      "version_simple": "0.5.1300",
+      "world_version": "0.5.1300"
     },
     "v1.4.1.1": {
       "created_at": "2025-10-08T20:15:17Z",
@@ -127,8 +127,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.1.1",
       "title": "Tevi Randomizer v1.4.1.1",
-      "version_simple": "1.4.1.1",
-      "world_version": "1.4.1.1"
+      "version_simple": "0.5.1411",
+      "world_version": "0.5.1411"
     },
     "v1.4.10": {
       "created_at": "2026-03-06T18:12:57Z",
@@ -142,8 +142,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.10",
       "title": "Version 1.4.10 Trap Test (AP v0.6.9)",
-      "version_simple": "1.4.10",
-      "world_version": "1.4.10"
+      "version_simple": "0.6.9",
+      "world_version": "0.6.9"
     },
     "v1.4.11": {
       "created_at": "2026-03-07T01:08:11Z",
@@ -157,8 +157,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.11",
       "title": "Version 1.4.11 Trap Test (AP v0.6.10)",
-      "version_simple": "1.4.11",
-      "world_version": "1.4.11"
+      "version_simple": "0.6.10",
+      "world_version": "0.6.10"
     },
     "v1.4.12": {
       "created_at": "2026-03-14T12:53:18Z",
@@ -172,8 +172,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.12",
       "title": "Version 1.4.12 Trap Test (AP v0.6.11)",
-      "version_simple": "1.4.12",
-      "world_version": "1.4.12"
+      "version_simple": "0.6.11",
+      "world_version": "0.6.11"
     },
     "v1.4.12r2": {
       "created_at": "2026-03-14T12:53:18Z",
@@ -187,8 +187,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.12r2",
       "title": "Version 1.4.12 Trap Test (AP v0.6.11)",
-      "version_simple": "1.4.12",
-      "world_version": "1.4.12.post2"
+      "version_simple": "0.6.11",
+      "world_version": "0.6.11.post2"
     },
     "v1.4.13": {
       "created_at": "2026-03-17T01:49:58Z",
@@ -202,8 +202,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.13",
       "title": "Version 1.4.13 Trap Test (AP v0.6.12)",
-      "version_simple": "1.4.13",
-      "world_version": "1.4.13"
+      "version_simple": "0.6.12",
+      "world_version": "0.6.12"
     },
     "v1.4.14": {
       "created_at": "2026-03-23T18:09:15Z",
@@ -217,8 +217,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.14",
       "title": "Version 1.4.14 Trap Test (AP v0.6.13)",
-      "version_simple": "1.4.14",
-      "world_version": "1.4.14"
+      "version_simple": "0.6.13",
+      "world_version": "0.6.13"
     },
     "v1.4.15": {
       "created_at": "2026-03-25T11:09:52Z",
@@ -232,8 +232,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.15",
       "title": "Version 1.4.15 Trap Test (AP v0.6.15)",
-      "version_simple": "1.4.15",
-      "world_version": "1.4.15"
+      "version_simple": "0.6.15",
+      "world_version": "0.6.15"
     },
     "v1.4.16": {
       "created_at": "2026-03-29T13:41:20Z",
@@ -247,8 +247,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.16",
       "title": "Version 1.4.16 Trap Test (AP v0.6.16)",
-      "version_simple": "1.4.16",
-      "world_version": "1.4.16"
+      "version_simple": "0.6.16",
+      "world_version": "0.6.16"
     },
     "v1.4.17": {
       "created_at": "2026-03-29T21:37:05Z",
@@ -262,8 +262,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.17",
       "title": "Version 1.4.17 Trap Test (AP v0.6.17)",
-      "version_simple": "1.4.17",
-      "world_version": "1.4.17"
+      "version_simple": "0.6.17",
+      "world_version": "0.6.17"
     },
     "v1.4.18-Bnyuu": {
       "created_at": "2026-03-29T21:37:05Z",
@@ -277,8 +277,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.18-Bnyuu",
       "title": "Version 1.4.18 Bnyuu (AP v0.6.18)",
-      "version_simple": "1.4.18",
-      "world_version": "1.4.18b0"
+      "version_simple": "0.6.18",
+      "world_version": "0.6.18"
     },
     "v1.4.19": {
       "created_at": "2026-04-06T10:54:05Z",
@@ -292,8 +292,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.19",
       "title": "Version 1.4.19 Trap Test (AP v0.6.19)",
-      "version_simple": "1.4.19",
-      "world_version": "1.4.19"
+      "version_simple": "0.6.19",
+      "world_version": "0.6.19"
     },
     "v1.4.20": {
       "created_at": "2026-04-06T10:54:05Z",
@@ -307,8 +307,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.20",
       "title": "Version 1.4.20 Trap Test (AP v0.6.20)",
-      "version_simple": "1.4.20",
-      "world_version": "1.4.20"
+      "version_simple": "0.6.20",
+      "world_version": "0.6.20"
     },
     "v1.4.3": {
       "created_at": "2025-11-28T19:49:52Z",
@@ -322,8 +322,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.3",
       "title": "Tevi Randomizer v1.4.3",
-      "version_simple": "1.4.3",
-      "world_version": "1.4.3"
+      "version_simple": "0.5.1430",
+      "world_version": "0.5.1430"
     },
     "v1.4.3.1": {
       "created_at": "2025-11-28T19:49:52Z",
@@ -337,8 +337,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.3.1",
       "title": "Tevi Randomizer v1.4.3.1",
-      "version_simple": "1.4.3.1",
-      "world_version": "1.4.3.1"
+      "version_simple": "0.5.1431",
+      "world_version": "0.5.1431"
     },
     "v1.4.3.2": {
       "created_at": "2025-12-25T19:55:03Z",
@@ -352,8 +352,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.3.2",
       "title": "Tevi Randomizer v1.4.3.2",
-      "version_simple": "1.4.3.2",
-      "world_version": "1.4.3.2"
+      "version_simple": "0.5.1432",
+      "world_version": "0.5.1432"
     },
     "v1.4.3.3": {
       "created_at": "2025-12-26T20:20:43Z",
@@ -367,8 +367,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.3.3",
       "title": "Tevi Randomizer v1.4.3.3",
-      "version_simple": "1.4.3.3",
-      "world_version": "1.4.3.3"
+      "version_simple": "0.5.1433",
+      "world_version": "0.5.1433"
     },
     "v1.4.3.4": {
       "created_at": "2025-12-28T08:49:31Z",
@@ -382,8 +382,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.3.4",
       "title": "Tevi Randomizer v1.4.3.4",
-      "version_simple": "1.4.3.4",
-      "world_version": "1.4.3.4"
+      "version_simple": "0.5.1434",
+      "world_version": "0.5.1434"
     },
     "v1.4.3.5": {
       "created_at": "2025-12-30T20:07:12Z",
@@ -397,8 +397,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.3.5",
       "title": "Tevi Randomizer v 1.4.3.5",
-      "version_simple": "1.4.3.5",
-      "world_version": "1.4.3.5"
+      "version_simple": "0.5.1435",
+      "world_version": "0.5.1435"
     },
     "v1.4.5": {
       "created_at": "2026-01-09T23:02:01Z",
@@ -411,8 +411,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.5",
       "title": "Tevi Randomizer v1.4.5 (AP 0.6.5)",
-      "version_simple": "1.4.5",
-      "world_version": "1.4.5"
+      "version_simple": "0.6.5",
+      "world_version": "0.6.5"
     },
     "v1.4.6": {
       "created_at": "2026-01-11T12:07:22Z",
@@ -425,8 +425,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.6",
       "title": "Tevi Randomizer v1.4.6 (AP 0.6.6)",
-      "version_simple": "1.4.6",
-      "world_version": "1.4.6"
+      "version_simple": "0.6.6",
+      "world_version": "0.6.6"
     },
     "v1.4.7": {
       "created_at": "2026-01-26T16:59:08Z",
@@ -439,8 +439,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.7",
       "title": "Tevi Randomizer v1.4.7 (AP 0.6.7)",
-      "version_simple": "1.4.7",
-      "world_version": "1.4.7"
+      "version_simple": "0.6.7",
+      "world_version": "0.6.7"
     },
     "v1.4.8": {
       "created_at": "2026-02-03T18:36:51Z",
@@ -453,8 +453,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.8",
       "title": "Tevi Randomizer v1.4.8 (AP 0.6.7)",
-      "version_simple": "1.4.8",
-      "world_version": "1.4.8"
+      "version_simple": "0.6.7",
+      "world_version": "0.6.7"
     },
     "v1.4.9": {
       "created_at": "2026-03-05T18:11:30Z",
@@ -468,8 +468,8 @@
       "source_url": "https://api.github.com/repos/BlackSoulKnight/Tevi_Randomizer",
       "tag": "v1.4.9",
       "title": "Version 1.4.9 Trap Test  (AP v0.6.8)",
-      "version_simple": "1.4.9",
-      "world_version": "1.4.9"
+      "version_simple": "0.6.8",
+      "world_version": "0.6.8"
     },
     "v1.5.0": {
       "created_at": "2026-05-12T11:32:59Z",


### PR DESCRIPTION
Replaced all client version to the proper AP version when able. Else shifted down to 0.5.<TAG_NUMBER_WITHOUT_DELIMITERS_FOUR_PADDING>. Example: 1.4.1 would become: 0.5.1410