### PR TITLE
Add - Crash Team Racing

### DIFF
--- a/index/ctr.yaml
+++ b/index/ctr.yaml
@@ -1,0 +1,2 @@
+github: https://github.com/dowlle/ctr-native-ap
+name: Crash Team Racing

--- a/recent.atom
+++ b/recent.atom
@@ -163,7 +163,7 @@ This update was very tricky to implement and would have been impossible without 
     </author>
     <content>## RaC3 APWorld v0.6.0
 
-**Branch:** main  
+**Branch:** main
 **Date:** 2026-07-10 10:37 UTC
 
 &lt;details&gt;
@@ -401,11 +401,11 @@ This update was very tricky to implement and would have been impossible without 
 ### [Setup Guide](https://github.com/Taoshix/Archipelago-RaC3/blob/staging/worlds/rac3/docs/setup_en.md)
 
 ### Notes
-This release was automatically generated from the **main** branch.  
+This release was automatically generated from the **main** branch.
 Latest (main) releases are recommended, as pre-releases (staging) may contain experimental or in-progress changes.
 
 ### If a location is broken and does not get sent out
-Go to the server console (locally or via the Archipelago room page) and run:  
+Go to the server console (locally or via the Archipelago room page) and run:
 `/send_location &lt;player_name&gt; &lt;location&gt;` Example: `/send_location TaoshiRaC3 "Crash Site: Infobot: Aridia"`
 </content>
     <link href="https://github.com/Taoshix/Archipelago-RaC3/releases/tag/v0.6.0"/>


### PR DESCRIPTION
Stub for **Crash Team Racing** (PSX, 1999) per the README's "manually create a yaml file" option - closes #195.

- Releases with `ctr.apworld` attached: https://github.com/dowlle/ctr-native-ap (semver tags, `v0.1.0` is the first public release)
- The apworld ships an `archipelago.json` manifest (game `Crash Team Racing`, world_version `0.1.0`, minimum AP `0.6.7`)
- The client is a decompiled-native PC build of the game with the AP client built in (no emulator, no ROM patching), bundled in the same releases

Thanks!
