### PR TITLE
[cuphead] Update the license identifier in index

### DIFF
--- a/index/cuphead.json
+++ b/index/cuphead.json
@@ -8,7 +8,7 @@
   ],
   "game": "Cuphead",
   "github": "https://github.com/JKLeckr/Archipelago-cuphead",
-  "license": "BSD-2-Clause",
+  "license": "MPL-2.0",
   "manifest_fields": [
     "authors",
     "flags",


### PR DESCRIPTION
Starting with the alpha03 series, the cuphead APWorld project's code is licensed under the MPL-2.0 license. This PR updates the license identifier in the project's index json.

I used `curl -L -H "Accept: application/vnd.github+json" https://api.github.com/repos/JKLeckr/Archipelago-cuphead/license` to verify that the GitHub API is returning the correct license which is:
```json
"license": {
    "key": "mpl-2.0",
    "name": "Mozilla Public License 2.0",
    "spdx_id": "MPL-2.0",
    "url": "https://api.github.com/licenses/mpl-2.0",
    "node_id": "MDc6TGljZW5zZTE0"
  }
```
